### PR TITLE
Fix for scope request

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ This method returns the slug of whatever target you are connected to. If not con
 
 ## getScope(codename)
 This method takes a codename and returns its scope as a list of dicts.
+
+**The first dict is the in scope items, and the second the out of scope items.**
+
 * `Host` targets return the CIDR notation ranges
 * `Web Application` targets return the expanded list of rules:
   * scheme: (http || https)

--- a/README.md
+++ b/README.md
@@ -136,9 +136,10 @@ This method takes a project slug and returns the target codename. This method is
 This method returns the slug of whatever target you are connected to. If not connected to a target, this will return `None`.
 
 ## getScope(codename)
-This method takes a codename and returns its scope as a list of dicts.
+This method takes a codename and returns its scope as two lists of dictionaries.
 
-**The first dict is the in scope items, and the second the out of scope items.**
+**The first list of dictionaries is the in-scope items, and the second list of dictionaries is the out of scope items.**
+
 
 * `Host` targets return the CIDR notation ranges
 * `Web Application` targets return the expanded list of rules:
@@ -165,6 +166,20 @@ https://www.example.com/*
     'wildcard': True
   }
 ]
+```
+
+So for example, if you wanted to retrieve a list of in-scope items, and only include those which were wildcards, only grab the domain, and ensure they are unique, you could do something like this:
+
+```
+scope = s1.getScope(codename)[0]
+current_set = set()
+for s in scope:
+     wildcard = s['wildcard']
+     if wildcard == True:
+         host = s['netloc']
+         if host not in current_set:
+             current_set.add(host)
+target_list = list(current_set)
 ```
 
 ## registerAll()

--- a/synack/synack.py
+++ b/synack/synack.py
@@ -24,6 +24,7 @@ from urllib.parse import urlparse
 
 warnings.filterwarnings("ignore")
 
+
 class synack:
     def __init__(self):
         self.session = requests.Session()
@@ -31,7 +32,9 @@ class synack:
         self.assessments = []
         self.token = ""
         self.notificationToken = ""
-        self.url_registered_summary = "https://platform.synack.com/api/targets/registered_summary"
+        self.url_registered_summary = (
+            "https://platform.synack.com/api/targets/registered_summary"
+        )
         self.url_scope_summary = "https://platform.synack.com/api/targets/"
         self.url_activate_target = "https://platform.synack.com/api/launchpoint"
         self.url_assessments = "https://platform.synack.com/api/assessments"
@@ -39,44 +42,54 @@ class synack:
         self.url_drafts = "https://platform.synack.com/api/drafts"
         self.url_unregistered_slugs = "https://platform.synack.com/api/targets?filter%5Bprimary%5D=unregistered&filter%5Bsecondary%5D=all&filter%5Bcategory%5D=all&sorting%5Bfield%5D=dateUpdated&sorting%5Bdirection%5D=desc&pagination%5Bpage%5D="
         self.url_profile = "https://platform.synack.com/api/profiles/me"
-        self.url_analytics = "https://platform.synack.com/api/listing_analytics/categories?listing_id="
+        self.url_analytics = (
+            "https://platform.synack.com/api/listing_analytics/categories?listing_id="
+        )
         self.url_hydra = "https://platform.synack.com/api/hydra_search/search/"
         self.url_logout = "https://platform.synack.com/api/logout"
-        self.url_notification_token = "https://platform.synack.com/api/users/notifications_token"
+        self.url_notification_token = (
+            "https://platform.synack.com/api/users/notifications_token"
+        )
         self.url_notification_api = "https://notifications.synack.com/api/v2/"
         self.url_transactions = "https://platform.synack.com/api/transactions"
-        self.url_lp_credentials = "https://platform.synack.com/api/launchpoint/credentials"
+        self.url_lp_credentials = (
+            "https://platform.synack.com/api/launchpoint/credentials"
+        )
         self.webheaders = {}
-        self.configFile = str(Path.home())+"/.synack/synack.conf"
-        self.firefoxProfile = str(Path.home())+"/.synack/selenium.profile"
+        self.configFile = str(Path.home()) + "/.synack/synack.conf"
+        self.firefoxProfile = str(Path.home()) + "/.synack/selenium.profile"
         self.config = configparser.ConfigParser()
         self.config.read(self.configFile)
-        self.email = self.config['DEFAULT']['email']
-        self.password = self.config['DEFAULT']['password']
-        self.login_wait = int(self.config['DEFAULT']['login_wait'])
-        self.login_url = self.config['DEFAULT']['login_url']
-        self.authySecret = self.config['DEFAULT']['authy_secret']
-        self.sessionTokenPath = self.config['DEFAULT'].get('session_token_path',"/tmp/synacktoken")
-        self.notificationTokenPath = self.config['DEFAULT'].get('notification_token_path',"/tmp/notificationtoken")
+        self.email = self.config["DEFAULT"]["email"]
+        self.password = self.config["DEFAULT"]["password"]
+        self.login_wait = int(self.config["DEFAULT"]["login_wait"])
+        self.login_url = self.config["DEFAULT"]["login_url"]
+        self.authySecret = self.config["DEFAULT"]["authy_secret"]
+        self.sessionTokenPath = self.config["DEFAULT"].get(
+            "session_token_path", "/tmp/synacktoken"
+        )
+        self.notificationTokenPath = self.config["DEFAULT"].get(
+            "notification_token_path", "/tmp/notificationtoken"
+        )
         self.connector = False
         self.webdriver = None
         self.headless = False
         # set to false to use the requests-based login
-        self.gecko = self.config['DEFAULT'].getboolean('gecko',True)
-        self.proxyport = self.config['DEFAULT'].getint('proxyport',8080)
+        self.gecko = self.config["DEFAULT"].getboolean("gecko", True)
+        self.proxyport = self.config["DEFAULT"].getint("proxyport", 8080)
 
-## Set to 'True' for troubleshooting with Burp Suite ##
-        self.Proxy = self.config['DEFAULT'].getboolean('proxy',False)
+        ## Set to 'True' for troubleshooting with Burp Suite ##
+        self.Proxy = self.config["DEFAULT"].getboolean("proxy", False)
 
-#########
+    #########
     def getAuthy(self):
         totp = pyotp.TOTP(self.authySecret)
         totp.digits = 7
         totp.interval = 10
         totp.issuer = "synack"
-        return(totp.now())
+        return totp.now()
 
-## Get Synack platform session token ##
+    ## Get Synack platform session token ##
     def getSessionToken(self):
         if Path(self.sessionTokenPath).exists():
             with open(self.sessionTokenPath, "r") as f:
@@ -87,25 +100,22 @@ class synack:
         self.webheaders = {"Authorization": "Bearer " + self.token}
         response = self.try_requests("GET", self.url_profile, 10)
         profile = response.json()
-        self.webheaders['user_id'] = profile['user_id']
+        self.webheaders["user_id"] = profile["user_id"]
 
-#################################################
-## Function to attempt requests multiple times ##
-#################################################
+    #################################################
+    ## Function to attempt requests multiple times ##
+    #################################################
 
     def try_requests(self, func, URL, times, extra=None):
-        http_proxy  = "http://127.0.0.1:%d" % self.proxyport
+        http_proxy = "http://127.0.0.1:%d" % self.proxyport
         https_proxy = "http://127.0.0.1:%d" % self.proxyport
-        proxyDict = {
-            "http" : http_proxy,
-            "https" : https_proxy
-        }
+        proxyDict = {"http": http_proxy, "https": https_proxy}
 
         url = urlparse(URL)
         scheme = url.scheme
         netloc = url.netloc
-        path   = url.path
-        port   = url.port
+        path = url.path
+        port = url.port
         platform = "platform.synack"
 
         if self.Proxy == True:
@@ -114,8 +124,14 @@ class synack:
                     if func == "PUT":
                         putData = json.dumps({"listing_id": extra})
                         newHeaders = dict(self.webheaders)
-                        newHeaders['Content-Type'] = "application/json"
-                        response = self.session.put(URL, headers=newHeaders, data=putData, proxies=proxyDict, verify=False)
+                        newHeaders["Content-Type"] = "application/json"
+                        response = self.session.put(
+                            URL,
+                            headers=newHeaders,
+                            data=putData,
+                            proxies=proxyDict,
+                            verify=False,
+                        )
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
@@ -123,22 +139,39 @@ class synack:
                             return response
                     elif func == "GET":
                         if extra == None:
-                            response = self.session.get(URL, headers=self.webheaders, proxies=proxyDict, verify=False)
+                            response = self.session.get(
+                                URL,
+                                headers=self.webheaders,
+                                proxies=proxyDict,
+                                verify=False,
+                            )
                             if response.status_code == 401 and platform in netloc:
                                 self.connectToPlatform()
                                 self.getSessionToken()
                             else:
                                 return response
                         else:
-                            parameters = {'page': extra}
-                            response = self.session.get(URL, headers=self.webheaders, params=parameters, proxies=proxyDict, verify=False)
+                            parameters = {"page": extra}
+                            response = self.session.get(
+                                URL,
+                                headers=self.webheaders,
+                                params=parameters,
+                                proxies=proxyDict,
+                                verify=False,
+                            )
                             if response.status_code == 401 and platform in netloc:
                                 self.connectToPlatform()
                                 self.getSessionToken()
                             else:
                                 return response
                     elif func == "POST":
-                        response = self.session.post(URL, headers=self.webheaders, proxies=proxyDict, json=extra, verify=False)
+                        response = self.session.post(
+                            URL,
+                            headers=self.webheaders,
+                            proxies=proxyDict,
+                            json=extra,
+                            verify=False,
+                        )
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
@@ -146,16 +179,28 @@ class synack:
                             return response
                     elif func == "PATCH":
                         newHeaders = dict(self.webheaders)
-                        newHeaders['Content-Type'] = "application/json"
+                        newHeaders["Content-Type"] = "application/json"
                         # PATCH request does not support `json=` parameter
-                        response = self.session.patch(URL, headers=newHeaders, proxies=proxyDict, data=extra, verify=False)
+                        response = self.session.patch(
+                            URL,
+                            headers=newHeaders,
+                            proxies=proxyDict,
+                            data=extra,
+                            verify=False,
+                        )
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
                         else:
                             return response
                     elif func == "DELETE":
-                        response = self.session.delete(URL, headers=self.webheaders, proxies=proxyDict, json=extra, verify=False)
+                        response = self.session.delete(
+                            URL,
+                            headers=self.webheaders,
+                            proxies=proxyDict,
+                            json=extra,
+                            verify=False,
+                        )
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
@@ -170,8 +215,10 @@ class synack:
                     if func == "PUT":
                         putData = json.dumps({"listing_id": extra})
                         newHeaders = dict(self.webheaders)
-                        newHeaders['Content-Type'] = "application/json"
-                        response =self.session.put(URL, headers=newHeaders, data=putData, verify=False)
+                        newHeaders["Content-Type"] = "application/json"
+                        response = self.session.put(
+                            URL, headers=newHeaders, data=putData, verify=False
+                        )
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
@@ -179,22 +226,31 @@ class synack:
                             return response
                     elif func == "GET":
                         if extra == None:
-                            response =self.session.get(URL, headers=self.webheaders, verify=False)
+                            response = self.session.get(
+                                URL, headers=self.webheaders, verify=False
+                            )
                             if response.status_code == 401 and platform in netloc:
                                 self.connectToPlatform()
                                 self.getSessionToken()
                             else:
                                 return response
                         else:
-                            parameters = {'page': extra}
-                            response = self.session.get(URL, headers=self.webheaders, params=parameters, verify=False)
+                            parameters = {"page": extra}
+                            response = self.session.get(
+                                URL,
+                                headers=self.webheaders,
+                                params=parameters,
+                                verify=False,
+                            )
                             if response.status_code == 401 and platform in netloc:
                                 self.connectToPlatform()
                                 self.getSessionToken()
                             else:
                                 return response
                     elif func == "POST":
-                        response =  self.session.post(URL, headers=self.webheaders, json=extra, verify=False)
+                        response = self.session.post(
+                            URL, headers=self.webheaders, json=extra, verify=False
+                        )
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
@@ -203,15 +259,19 @@ class synack:
                     elif func == "PATCH":
                         # PATCH request does not support `json=` parameter
                         newHeaders = dict(self.webheaders)
-                        newHeaders['Content-Type'] = "application/json"
-                        response = self.session.request("PATCH", URL, headers=newHeaders, data=extra, verify=False)
+                        newHeaders["Content-Type"] = "application/json"
+                        response = self.session.request(
+                            "PATCH", URL, headers=newHeaders, data=extra, verify=False
+                        )
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
                         else:
                             return response
                     elif func == "DELETE":
-                        response = self.session.delete(URL, headers=self.webheaders, json=extra, verify=False)
+                        response = self.session.delete(
+                            URL, headers=self.webheaders, json=extra, verify=False
+                        )
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
@@ -223,10 +283,9 @@ class synack:
                     last_err = err
             raise last_err
 
-
-####################################################
-## Function to find all occurrences of nested key ##
-####################################################
+    ####################################################
+    ## Function to find all occurrences of nested key ##
+    ####################################################
 
     def findkeys(self, node, kv):
         if isinstance(node, list):
@@ -240,26 +299,32 @@ class synack:
                 for x in self.findkeys(j, kv):
                     yield x
 
-##############################################
-## Returns a JSON of all registered targets ##
-## This must be the first call after object ##
-## instantiation - it populates the json    ##
-##############################################
+    ##############################################
+    ## Returns a JSON of all registered targets ##
+    ## This must be the first call after object ##
+    ## instantiation - it populates the json    ##
+    ##############################################
     def getAllTargets(self):
         self.jsonResponse.clear()
         response = self.try_requests("GET", self.url_registered_summary, 10)
         self.jsonResponse[:] = response.json()
-        return(response.status_code)
+        return response.status_code
 
-
-########################################
-## Returns a list of web or host target codenames
-## that are (mission only / not mission only)
-## category: web || host || RE || mobile || sourceCode || hardware
-## mission_only: True || False
-########################################
+    ########################################
+    ## Returns a list of web or host target codenames
+    ## that are (mission only / not mission only)
+    ## category: web || host || RE || mobile || sourceCode || hardware
+    ## mission_only: True || False
+    ########################################
     def getCodenames(self, category, mission_only=False):
-        categories = ("web application", "re", "mobile", "host", "source code","hardware")
+        categories = (
+            "web application",
+            "re",
+            "mobile",
+            "host",
+            "source code",
+            "hardware",
+        )
         category = category.lower()
         if category == "web":
             category = "web application"
@@ -270,255 +335,215 @@ class synack:
         if category not in categories:
             raise Exception("Invalid category.")
         targets = []
-        for i in range (len(self.jsonResponse)):
+        for i in range(len(self.jsonResponse)):
             if mission_only == True:
-                if self.jsonResponse[i]['vulnerability_discovery'] == False:
-                    if self.jsonResponse[i]['category']['name'].lower() == category.lower():
-                        targets.append(self.jsonResponse[i]['codename'])
+                if self.jsonResponse[i]["vulnerability_discovery"] == False:
+                    if (
+                        self.jsonResponse[i]["category"]["name"].lower()
+                        == category.lower()
+                    ):
+                        targets.append(self.jsonResponse[i]["codename"])
                     else:
                         continue
                 else:
                     continue
             elif mission_only == False:
-                if self.jsonResponse[i]['vulnerability_discovery'] == True:               
-                    if self.jsonResponse[i]['category']['name'].lower() == category.lower():
-                        targets.append(self.jsonResponse[i]['codename'])
+                if self.jsonResponse[i]["vulnerability_discovery"] == True:
+                    if (
+                        self.jsonResponse[i]["category"]["name"].lower()
+                        == category.lower()
+                    ):
+                        targets.append(self.jsonResponse[i]["codename"])
                     else:
                         continue
                 else:
                     continue
-        return(targets)
+        return targets
 
-#########################################
-## This returns the "slug" of a target ##
-## based on the codename ##
-#########################################
+    #########################################
+    ## This returns the "slug" of a target ##
+    ## based on the codename ##
+    #########################################
 
     def getTargetID(self, codename):
-        for i in range (len(self.jsonResponse)):
-            if self.jsonResponse[i]['codename'].lower() == codename.lower():
-                return(self.jsonResponse[i]['id'])
+        for i in range(len(self.jsonResponse)):
+            if self.jsonResponse[i]["codename"].lower() == codename.lower():
+                return self.jsonResponse[i]["id"]
 
-##################################
-## This retuens the codemane of ##
-## a target based on the slug   ##
-##################################
+    ##################################
+    ## This retuens the codemane of ##
+    ## a target based on the slug   ##
+    ##################################
     def getCodenameFromSlug(self, slug):
         for i in range(len(self.jsonResponse)):
-            if self.jsonResponse[i]['id'].lower() == slug.lower():
-                return(self.jsonResponse[i]['codename'])
+            if self.jsonResponse[i]["id"].lower() == slug.lower():
+                return self.jsonResponse[i]["codename"]
 
-#################################
-## This private method returns ##
-## the organization ID         ##
-#################################
+    #################################
+    ## This private method returns ##
+    ## the organization ID         ##
+    #################################
     def __getOrgID(self, codename):
-        for i in range (len(self.jsonResponse)):
-            if self.jsonResponse[i]['codename'].lower() == codename.lower():
-                return(self.jsonResponse[i]['organization_id'])
+        for i in range(len(self.jsonResponse)):
+            if self.jsonResponse[i]["codename"].lower() == codename.lower():
+                return self.jsonResponse[i]["organization_id"]
 
-######################################
-## This returns the target category ##
-######################################
+    ######################################
+    ## This returns the target category ##
+    ######################################
     def getCategory(self, codename):
-        for i in range (len(self.jsonResponse)):
-            if self.jsonResponse[i]['codename'].lower() == codename.lower():
-                return(self.jsonResponse[i]['category']['name'])
+        for i in range(len(self.jsonResponse)):
+            if self.jsonResponse[i]["codename"].lower() == codename.lower():
+                return self.jsonResponse[i]["category"]["name"]
 
-#####################################################
-## This will connect you to the target by codename ##
-#####################################################
+    #####################################################
+    ## This will connect you to the target by codename ##
+    #####################################################
     def connectToTarget(self, codename):
         slug = self.getTargetID(codename)
         response = self.try_requests("PUT", self.url_activate_target, 10, slug)
         time.sleep(5)
         return response.status_code
-        
-#####################################################
-## This will disconnect you from the target        ##
-#####################################################
+
+    #####################################################
+    ## This will disconnect you from the target        ##
+    #####################################################
     def disconnectTarget(self):
         response = self.try_requests("PUT", self.url_activate_target, 10, "")
         time.sleep(5)
         return response.status_code
 
-########################################################
-## This just returns the "real" client name sometimes ##
-########################################################
+    ########################################################
+    ## This just returns the "real" client name sometimes ##
+    ########################################################
     def clientName(self, codename):
-        for i in range (len(self.jsonResponse)):
-            if self.jsonResponse[i]['codename'].lower() == codename.lower():
-                return(self.jsonResponse[i]['name'])
+        for i in range(len(self.jsonResponse)):
+            if self.jsonResponse[i]["codename"].lower() == codename.lower():
+                return self.jsonResponse[i]["name"]
 
+    ################################
+    ## This gets the target scope ##
+    ################################
 
-################################
-## This gets the target scope ##
-################################
+    @staticmethod
+    def parseScope(scopeList):
+
+        results = []
+
+        for i in scopeList:
+
+            scopeRule = i["rule"]
+            scopeType = i["scope"]
+
+            port = None
+            scopeRule = scopeRule.rstrip("*")
+            wildcard = False
+
+            if scopeRule[0] == "*":
+                wildcard = True
+
+                scopeRule = ".".join(scopeRule.split(".")[1:])
+            else:
+                wildcard = True
+
+            if ":" in scopeRule:
+                port = scopeRule.split(":")[1].split("/")[0]
+                scopeRule = scopeRule.split(":")[0]
+
+            if not scopeRule.startswith("http"):
+
+                if port and port in [8000, 80, 8080]:
+                    scopeRule = f"http://{scopeRule}"
+
+                else:
+                    scopeRule = f"https://{scopeRule}"
+
+            url = urlparse(scopeRule)
+
+            scopeDict = {
+                "scheme": url.scheme,
+                "netloc": url.netloc,
+                "path": url.path,
+                "port": url.port,
+                "wildcard": wildcard,
+                "fullURI": f"{url.scheme}://{url.netloc}",
+            }
+            if (scopeType, scopeDict) not in results:
+                results.append((scopeType, scopeDict))
+        return list(results)
 
     def getScope(self, codename):
-        category = self.getCategory(codename) 
+        category = self.getCategory(codename)
         orgID = self.__getOrgID(codename)
         slug = self.getTargetID(codename)
         if category.lower() == "web application":
-            scopeURL = "https://platform.synack.com/api/asset/v1/organizations/"+orgID+"/owners/listings/"+slug+"/webapps"
-            allRules = []
+            scopeURL = f"https://platform.synack.com/api/asset/v2/assets?organizationUid[]={orgID}&listingUid[]={slug}"
+            inScopeRules = []
             oosRules = []
             response = self.try_requests("GET", scopeURL, 10)
             jsonResponse = response.json()
-            j = 0
-            while j < len(jsonResponse):
-                if jsonResponse[j]['status'] in ["out","tbd"]:
-                    tmpOOS = set()
-                    for thisRule in range(len(jsonResponse[j]['rules'])):
-                        url = urlparse(jsonResponse[j]['rules'][thisRule]['rule'])
-                        scheme = url.scheme
-                        netloc = url.netloc
-                        path   = url.path
-                        port   = url.port
-                        wildcard = False
-                        if len(netloc) != 0:
-                            subdomain = netloc.split('.')[0]
-                            if subdomain == "*":
-                                wildcard = True
-                                netloc = ".".join(netloc.split('.')[1:])
-                        else:
-                            if len(path) != 0:
-                                netloc = path.split('/')[0]
-                                checkWildcard = netloc.split('.')[0]
-                                if checkWildcard == "*":
-                                    wildcard = True
-                                    if ":" in netloc:
-                                        port = netloc.split(':')[1]
-                                        thisURL = netloc.split(':')[0]
-                                        netloc = ".".join(thisURL.split('.')[1:])
-                                    else:
-                                        port = 443
-                                        netloc = ".".join(netloc.split('.')[1:])
-                                else:
-                                    if ":" in netloc:
-                                        port = netloc.split(':')[1]
-                                        thisURL = netloc.split(':')[0]
-                                        netloc = ".".join(thisURL.split('.')[0:])
-                                    else:
-                                        port = 443
-                                        netloc = ".".join(netloc.split('.')[0:])
-                                path = "/" + "/".join(path.split('/')[1:])
-                            else:
-                                continue
-                        oosDict = {
-                                        'scheme' : scheme,
-                                        'netloc': netloc,
-                                        'path': path,
-                                        'port': port,
-                                        'wildcard': wildcard,
-                                        'fullURI' : scheme+netloc
+            for scopeListing in jsonResponse:
 
-                        }
-                    oosRules.append(oosDict)            
-                    j+=1
-                else:
-                    for thisRule in range(len(jsonResponse[j]['rules'])):
-                        url = urlparse(jsonResponse[j]['rules'][thisRule]['rule'])
-                        scheme = url.scheme
-                        netloc = url.netloc
-                        path   = url.path
-                        port   = url.port
-                        wildcard = False
+                listingType = scopeListing["listings"][0]["scope"]
 
-                        if len(netloc) != 0:
-                            subdomain = netloc.split('.')[0]
-                            if subdomain == "*":
-                                wildcard = True
-                                netloc = ".".join(netloc.split('.')[1:])
-                        else:
-                            if len(path) != 0:
-                                netloc = path.split('/')[0]
-                                checkWildcard = netloc.split('.')[0]
-                                if checkWildcard == "*":
-                                    wildcard = True
-                                    if ":" in netloc:
-                                        port = netloc.split(':')[1]
-                                        thisURL = netloc.split(':')[0]
-                                        netloc = ".".join(thisURL.split('.')[1:])
-                                    else:
-                                        port = 443
-                                        netloc = ".".join(netloc.split('.')[1:])
-                                else:
-                                    if ":" in netloc:
-                                        port = netloc.split(':')[1]
-                                        thisURL = netloc.split(':')[0]
-                                        netloc = ".".join(thisURL.split('.')[0:])
-                                    else:
-                                        port = 443
-                                        netloc = ".".join(netloc.split('.')[0:])
-                                path = "/" + "/".join(path.split('/')[1:])
-                            else:
-                                continue
-                        if jsonResponse[j]['rules'][thisRule]['status'] in ["out","tbd"]:
-                            oosDict = {
-                                        'scheme' : scheme,
-                                        'netloc': netloc,
-                                        'path': path,
-                                        'port': port,
-                                        'wildcard': wildcard,
-                                        'fullURI' : scheme+netloc
+                for scopeTuple in self.parseScope(scopeListing["scopeRules"]):
+                    scopeType = scopeTuple[0]
+                    scopeDict = scopeTuple[1]
 
-                            }
-                            oosRules.append(oosDict)
-                            continue
-                        else:
-                            pass
+                    if scopeType == "in" and listingType == "in":
+                        inScopeRules.append(scopeDict)
+                    else:
+                        oosRules.append(scopeDict)
 
-                        scopeDict = {
-                                        'scheme' : scheme,
-                                        'netloc': netloc,
-                                        'path': path,
-                                        'port': port,
-                                        'wildcard': wildcard,
-                                        'fullURI' : scheme+netloc
-                                    }
-                        allRules.append(scopeDict)
-                    j+=1
-            return(list(allRules),list(oosRules))
+            return (list(inScopeRules), list(oosRules))
         if category.lower() == "host":
-            scopeURL = "https://platform.synack.com/api/targets/"+slug+"/cidrs?page=all"
+            scopeURL = (
+                "https://platform.synack.com/api/targets/" + slug + "/cidrs?page=all"
+            )
             cidrs = []
             try:
                 response = self.try_requests("GET", scopeURL, 10)
             except requests.exceptions.RequestException as e:
                 raise SystemExit(e)
-            temp = json.dumps(response.json()['cidrs']).replace("[","").replace("]","").replace("\"","").replace(", ","\n").split("\n")
+            temp = (
+                json.dumps(response.json()["cidrs"])
+                .replace("[", "")
+                .replace("]", "")
+                .replace('"', "")
+                .replace(", ", "\n")
+                .split("\n")
+            )
             cidrs.extend(temp)
             cidrs = list(set(cidrs))
-            return(cidrs)
+            return cidrs
 
-########################################
-## This converts CIDR list to IP list ##
-## This is a much faster method, previous method was causing problems on large hosts ##
-########################################
+    ########################################
+    ## This converts CIDR list to IP list ##
+    ## This is a much faster method, previous method was causing problems on large hosts ##
+    ########################################
     def getIPs(self, cidrs):
         IPs = []
         for i in range(len(cidrs)):
             if cidrs[i] != "":
                 for ip in IPNetwork(cidrs[i]):
                     IPs.append(str(ip))
-        return(IPs)
-    
-##############################################
-## This gets all of your passed assessments ##
-##############################################
+        return IPs
+
+    ##############################################
+    ## This gets all of your passed assessments ##
+    ##############################################
     def getAssessments(self):
         self.assessments.clear()
         response = self.try_requests("GET", self.url_assessments, 10)
         jsonResponse = response.json()
         for i in range(len(jsonResponse)):
-            if jsonResponse[i]['written_assessment']['passed'] == True:
-                self.assessments.append(jsonResponse[i]['category_name'])
-            i+=1
+            if jsonResponse[i]["written_assessment"]["passed"] == True:
+                self.assessments.append(jsonResponse[i]["category_name"])
+            i += 1
 
-##########################################################
-## This gets endpoints from Web Application "Analytics" ##
-##########################################################
+    ##########################################################
+    ## This gets endpoints from Web Application "Analytics" ##
+    ##########################################################
     def getAnalytics(self, codename, status="all"):
         slug = self.getTargetID(codename)
         if status.lower() == "accepted":
@@ -535,114 +560,191 @@ class synack:
         targetType = self.getCategory(codename)
         if targetType == "Web Application":
             if "value" in jsonResponse:
-                for value in range(len(jsonResponse['value'])):
-                    for exploitable_location in range(len(jsonResponse['value'][value]['exploitable_locations'])):
+                for value in range(len(jsonResponse["value"])):
+                    for exploitable_location in range(
+                        len(jsonResponse["value"][value]["exploitable_locations"])
+                    ):
                         analyticsDict = {}
-                        if jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['type'] == "url":
+                        if (
+                            jsonResponse["value"][value]["exploitable_locations"][
+                                exploitable_location
+                            ]["type"]
+                            == "url"
+                        ):
                             try:
-                                URI = urlparse(str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['value']))
+                                URI = urlparse(
+                                    str(
+                                        jsonResponse["value"][value][
+                                            "exploitable_locations"
+                                        ][exploitable_location]["value"]
+                                    )
+                                )
                                 scheme = URI.scheme
                             except:
                                 scheme = "https"
-## URL
-#                                analyticsDict['uri'] = urlparse(str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['value']))
+                            ## URL
+                            #                                analyticsDict['uri'] = urlparse(str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['value']))
                             port = str(URI.port)
                             if port != "None":
-                                analyticsDict['port'] = port
+                                analyticsDict["port"] = port
                             else:
                                 if scheme == "http":
-                                    analyticsDict['port'] = "80"
+                                    analyticsDict["port"] = "80"
                                 elif scheme == "https":
-                                    analyticsDict['port'] = "443"
-                            analyticsDict['codename'] = codename
-                            analyticsDict['vuln_category'] = str(jsonResponse['value'][value]['categories'][0])
-                            if len(jsonResponse['value'][value]['categories']) == 2:
-                                analyticsDict['vuln_subcategory'] = str(jsonResponse['value'][value]['categories'][1])
+                                    analyticsDict["port"] = "443"
+                            analyticsDict["codename"] = codename
+                            analyticsDict["vuln_category"] = str(
+                                jsonResponse["value"][value]["categories"][0]
+                            )
+                            if len(jsonResponse["value"][value]["categories"]) == 2:
+                                analyticsDict["vuln_subcategory"] = str(
+                                    jsonResponse["value"][value]["categories"][1]
+                                )
                             else:
                                 pass
-                            analyticsDict['scheme'] = "URL"
+                            analyticsDict["scheme"] = "URL"
                             try:
-                                analyticsDict['protocol'] = URI.scheme
+                                analyticsDict["protocol"] = URI.scheme
                             except:
-                                analyticsDict['protocol'] = "http"
+                                analyticsDict["protocol"] = "http"
                                 pass
                             try:
-                                analyticsDict['vuln_location'] = analyticsDict['protocol'] + "://" + URI.netloc + URI.path
+                                analyticsDict["vuln_location"] = (
+                                    analyticsDict["protocol"]
+                                    + "://"
+                                    + URI.netloc
+                                    + URI.path
+                                )
                             except:
-                                analyticsDict['vuln_location'] = ""
+                                analyticsDict["vuln_location"] = ""
                                 pass
                             if status.lower() == "rejected":
-                                analyticsDict['status'] = "rejected"
+                                analyticsDict["status"] = "rejected"
                             else:
-                                analyticsDict['status'] = str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['status'])
+                                analyticsDict["status"] = str(
+                                    jsonResponse["value"][value][
+                                        "exploitable_locations"
+                                    ][exploitable_location]["status"]
+                                )
                             analytics.append(analyticsDict)
             return analytics
         elif targetType == "Host":
-#'codename', 'vuln_category', 'vuln_subcategory', 'vuln_location', 'type', 'protocol', 'port', 'path', 'status'
+            #'codename', 'vuln_category', 'vuln_subcategory', 'vuln_location', 'type', 'protocol', 'port', 'path', 'status'
             if "value" in jsonResponse:
-                for value in range(len(jsonResponse['value'])):
-                    for exploitable_location in range(len(jsonResponse['value'][value]['exploitable_locations'])):
+                for value in range(len(jsonResponse["value"])):
+                    for exploitable_location in range(
+                        len(jsonResponse["value"][value]["exploitable_locations"])
+                    ):
                         analyticsDict = {}
-                        if jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['type'] == "url":
+                        if (
+                            jsonResponse["value"][value]["exploitable_locations"][
+                                exploitable_location
+                            ]["type"]
+                            == "url"
+                        ):
                             try:
-                                URI = urlparse(str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['value']))
+                                URI = urlparse(
+                                    str(
+                                        jsonResponse["value"][value][
+                                            "exploitable_locations"
+                                        ][exploitable_location]["value"]
+                                    )
+                                )
                                 scheme = URI.scheme
                             except:
                                 scheme = "https"
-## URL
-#                                analyticsDict['uri'] = urlparse(str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['value']))
+                            ## URL
+                            #                                analyticsDict['uri'] = urlparse(str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['value']))
                             port = str(URI.port)
                             if port != "None":
-                                analyticsDict['port'] = port
+                                analyticsDict["port"] = port
                             else:
                                 if scheme == "http":
-                                    analyticsDict['port'] = "80"
+                                    analyticsDict["port"] = "80"
                                 elif scheme == "https":
-                                    analyticsDict['port'] = "443"
-                            analyticsDict['codename'] = codename
-                            analyticsDict['vuln_category'] = str(jsonResponse['value'][value]['categories'][0])
-                            if len(jsonResponse['value'][value]['categories']) == 2:
-                                analyticsDict['vuln_subcategory'] = str(jsonResponse['value'][value]['categories'][1])
+                                    analyticsDict["port"] = "443"
+                            analyticsDict["codename"] = codename
+                            analyticsDict["vuln_category"] = str(
+                                jsonResponse["value"][value]["categories"][0]
+                            )
+                            if len(jsonResponse["value"][value]["categories"]) == 2:
+                                analyticsDict["vuln_subcategory"] = str(
+                                    jsonResponse["value"][value]["categories"][1]
+                                )
                             else:
                                 pass
-                            analyticsDict['scheme'] = "URL"
+                            analyticsDict["scheme"] = "URL"
                             try:
-                                analyticsDict['protocol'] = URI.scheme
+                                analyticsDict["protocol"] = URI.scheme
                             except:
-                                analyticsDict['protocol'] = "http"
+                                analyticsDict["protocol"] = "http"
                                 pass
                             try:
-                                analyticsDict['vuln_location'] = analyticsDict['protocol'] + "://" + URI.netloc + URI.path
+                                analyticsDict["vuln_location"] = (
+                                    analyticsDict["protocol"]
+                                    + "://"
+                                    + URI.netloc
+                                    + URI.path
+                                )
                             except:
-                                analyticsDict['vuln_location'] = ""
+                                analyticsDict["vuln_location"] = ""
                                 pass
                             if status.lower() == "rejected":
-                                analyticsDict['status'] = "rejected"
+                                analyticsDict["status"] = "rejected"
                             else:
-                                analyticsDict['status'] = str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['status'])
+                                analyticsDict["status"] = str(
+                                    jsonResponse["value"][value][
+                                        "exploitable_locations"
+                                    ][exploitable_location]["status"]
+                                )
                             analytics.append(analyticsDict)
-                        elif jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['type'] == "ip":
-## IP
-                            analyticsDict['codename'] = codename
-                            analyticsDict['vuln_category'] = str(jsonResponse['value'][value]['categories'][0])
-                            if len(jsonResponse['value'][value]['categories']) == 2:
-                                analyticsDict['vuln_subcategory'] = str(jsonResponse['value'][value]['categories'][1])
+                        elif (
+                            jsonResponse["value"][value]["exploitable_locations"][
+                                exploitable_location
+                            ]["type"]
+                            == "ip"
+                        ):
+                            ## IP
+                            analyticsDict["codename"] = codename
+                            analyticsDict["vuln_category"] = str(
+                                jsonResponse["value"][value]["categories"][0]
+                            )
+                            if len(jsonResponse["value"][value]["categories"]) == 2:
+                                analyticsDict["vuln_subcategory"] = str(
+                                    jsonResponse["value"][value]["categories"][1]
+                                )
                             else:
                                 pass
-                            analyticsDict['scheme'] = "HOST"
-                            analyticsDict['protocol'] = str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['protocol'])
-                            analyticsDict['vuln_location'] = str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['address'])
-                            analyticsDict['port'] = str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['port'])
+                            analyticsDict["scheme"] = "HOST"
+                            analyticsDict["protocol"] = str(
+                                jsonResponse["value"][value]["exploitable_locations"][
+                                    exploitable_location
+                                ]["protocol"]
+                            )
+                            analyticsDict["vuln_location"] = str(
+                                jsonResponse["value"][value]["exploitable_locations"][
+                                    exploitable_location
+                                ]["address"]
+                            )
+                            analyticsDict["port"] = str(
+                                jsonResponse["value"][value]["exploitable_locations"][
+                                    exploitable_location
+                                ]["port"]
+                            )
                             if status.lower() == "rejected":
-                                analyticsDict['status'] = "rejected"
+                                analyticsDict["status"] = "rejected"
                             else:
-                                analyticsDict['status'] = str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['status'])
+                                analyticsDict["status"] = str(
+                                    jsonResponse["value"][value][
+                                        "exploitable_locations"
+                                    ][exploitable_location]["status"]
+                                )
                             analytics.append(analyticsDict)
             return analytics
 
-#############################################
-## This registers all unregistered targets ##
-#############################################
+    #############################################
+    ## This registers all unregistered targets ##
+    #############################################
 
     def registerAll(self):
         self.getAssessments()
@@ -653,30 +755,34 @@ class synack:
             url_slugs = self.url_unregistered_slugs + str(pageNum)
             response = self.try_requests("GET", url_slugs, 10)
             jsonResponse = response.json()
-            if (len(jsonResponse)!=0):
-                for i in range (len(jsonResponse)):
+            if len(jsonResponse) != 0:
+                for i in range(len(jsonResponse)):
                     if jsonResponse[i]["category"]["name"] in self.assessments:
                         unregistered_slugs.append(str(jsonResponse[i]["slug"]))
                 pageNum += 1
             else:
                 next_page = False
                 pageNum += 1
-        for i in range (len(unregistered_slugs)): 
-            url_register_slug = "https://platform.synack.com/api/targets/"+unregistered_slugs[i]+"/signup"
-            data='{"ResearcherListing":{"terms":1}}'
+        for i in range(len(unregistered_slugs)):
+            url_register_slug = (
+                "https://platform.synack.com/api/targets/"
+                + unregistered_slugs[i]
+                + "/signup"
+            )
+            data = '{"ResearcherListing":{"terms":1}}'
             response = self.try_requests("POST", url_register_slug, 10, data)
             slug = unregistered_slugs[i]
         self.getAllTargets()
         for i in range(len(unregistered_slugs)):
             codename = self.getCodenameFromSlug(unregistered_slugs[i])
             if codename == None:
-                print("Error registerring "+unregistered_slugs[i]+"!")
+                print("Error registerring " + unregistered_slugs[i] + "!")
             else:
-                print("Successfully registered "+str(codename))
+                print("Successfully registered " + str(codename))
 
-###############
-## Keepalive ##
-###############
+    ###############
+    ## Keepalive ##
+    ###############
 
     def connectToPlatform(self):
         if self.gecko:
@@ -690,49 +796,60 @@ class synack:
         # <meta name="csrf-token" content="..."/>
         m = re.search('<meta name="csrf-token" content="([^"]*)"', response.text)
         csrf_token = m.group(1)
-        self.webheaders['X-CSRF-Token'] = csrf_token
+        self.webheaders["X-CSRF-Token"] = csrf_token
 
-        # fix broken Incapsula cookies - regression removed 
+        # fix broken Incapsula cookies - regression removed
         for cookie_name in self.session.cookies.iterkeys():
             cookie_value = self.session.cookies.get(cookie_name)
             if cookie_value.find("\r") > -1 or cookie_value.find("\n") > -1:
                 print("Fixing cookie %s" % cookie_name)
-                cookie_value = re.sub("\r\n *","", cookie_value)
-                cookie_obj = requests.cookies.create_cookie(name=cookie_name,value=cookie_value,path="/")
-                self.session.cookies.clear(domain="login.synack.com",path="/",name=cookie_name)
+                cookie_value = re.sub("\r\n *", "", cookie_value)
+                cookie_obj = requests.cookies.create_cookie(
+                    name=cookie_name, value=cookie_value, path="/"
+                )
+                self.session.cookies.clear(
+                    domain="login.synack.com", path="/", name=cookie_name
+                )
                 self.session.cookies.set_cookie(cookie_obj)
 
-        data={"email":self.email,"password":self.password}
-        response = self.try_requests("POST", "https://login.synack.com/api/authenticate", 1, data)
+        data = {"email": self.email, "password": self.password}
+        response = self.try_requests(
+            "POST", "https://login.synack.com/api/authenticate", 1, data
+        )
         jsonResponse = response.json()
-        if not jsonResponse['success']:
-            print("Error logging in: "+jsonResponse)
+        if not jsonResponse["success"]:
+            print("Error logging in: " + jsonResponse)
             return False
-        
-        progress_token = jsonResponse['progress_token']
 
-        data={"authy_token":self.getAuthy(),"progress_token":progress_token}
-        response = self.try_requests("POST", "https://login.synack.com/api/authenticate", 1, data)
+        progress_token = jsonResponse["progress_token"]
+
+        data = {"authy_token": self.getAuthy(), "progress_token": progress_token}
+        response = self.try_requests(
+            "POST", "https://login.synack.com/api/authenticate", 1, data
+        )
         jsonResponse = response.json()
 
-        grant_token = jsonResponse['grant_token']
+        grant_token = jsonResponse["grant_token"]
 
         # 2 requests required here to confirm the grant token - once to the HTML page and once to the API
-        response = self.try_requests("GET", "https://platform.synack.com/?grant_token="+grant_token, 1)
-        self.webheaders['X-Requested-With'] = "XMLHttpRequest"
-        response = self.try_requests("GET", "https://platform.synack.com/token?grant_token="+grant_token, 1)
+        response = self.try_requests(
+            "GET", "https://platform.synack.com/?grant_token=" + grant_token, 1
+        )
+        self.webheaders["X-Requested-With"] = "XMLHttpRequest"
+        response = self.try_requests(
+            "GET", "https://platform.synack.com/token?grant_token=" + grant_token, 1
+        )
         jsonResponse = response.json()
-        access_token = jsonResponse['access_token']
+        access_token = jsonResponse["access_token"]
 
         self.token = access_token
-        with open(self.sessionTokenPath,"w") as f:
+        with open(self.sessionTokenPath, "w") as f:
             f.write(self.token)
         f.close()
 
         # Remove these headers so they don't affect other requests
-        del self.webheaders['X-Requested-With']
-        del self.webheaders['X-CSRF-Token']
-
+        del self.webheaders["X-Requested-With"]
+        del self.webheaders["X-CSRF-Token"]
 
     def connectToPlatformGecko(self):
         isExist = os.path.exists(self.firefoxProfile)
@@ -742,40 +859,44 @@ class synack:
         options.add_argument("-profile")
         options.add_argument(self.firefoxProfile)
         firefox_capabilities = DesiredCapabilities.FIREFOX
-        firefox_capabilities['marionette'] = True
+        firefox_capabilities["marionette"] = True
 
         if self.headless == True:
             options.headless = True
         else:
             options.headless = False
-#        driver = webdriver.Firefox(options=options)
+        #        driver = webdriver.Firefox(options=options)
         driver = webdriver.Firefox(capabilities=firefox_capabilities, options=options)
         driver.get(self.login_url)
         assert "Synack" in driver.title
-## Fill in the email address ##
-        email_path = '/html/body/div[2]/div/div/div[2]/form/fieldset/input'
+        ## Fill in the email address ##
+        email_path = "/html/body/div[2]/div/div/div[2]/form/fieldset/input"
         driver.find_element_by_xpath(email_path).click()
         driver.find_element_by_xpath(email_path).send_keys(self.email)
-## Fill in the password ##
-        password_path = '/html/body/div[2]/div/div/div[2]/form/fieldset/div[1]/input'
+        ## Fill in the password ##
+        password_path = "/html/body/div[2]/div/div/div[2]/form/fieldset/div[1]/input"
         driver.find_element_by_xpath(password_path).click()
         driver.find_element_by_xpath(password_path).send_keys(self.password)
-## Click the login button ##
-        login_path = '/html/body/div[2]/div/div/div[2]/form/fieldset/div[2]/button'
+        ## Click the login button ##
+        login_path = "/html/body/div[2]/div/div/div[2]/form/fieldset/div[2]/button"
         driver.find_element_by_xpath(login_path).click()
         time.sleep(5)
-## Hope the authy works! ##
-        authy_path = '/html/body/div[2]/div/div/div[2]/form/fieldset/input'
+        ## Hope the authy works! ##
+        authy_path = "/html/body/div[2]/div/div/div[2]/form/fieldset/input"
         driver.find_element_by_xpath(authy_path).click()
         driver.find_element_by_xpath(authy_path).send_keys(self.getAuthy())
-        authy_submit_path = '/html/body/div[2]/div/div/div[2]/form/fieldset/div[1]/button'
+        authy_submit_path = (
+            "/html/body/div[2]/div/div/div[2]/form/fieldset/div[1]/button"
+        )
         driver.find_element_by_xpath(authy_submit_path).click()
         while True:
-            self.token = driver.execute_script("return sessionStorage.getItem('shared-session-com.synack.accessToken')")
+            self.token = driver.execute_script(
+                "return sessionStorage.getItem('shared-session-com.synack.accessToken')"
+            )
             if isinstance(self.token, str):
                 break
-## Write the session token to /tmp/synacktoken ##
-        with open(self.sessionTokenPath,"w") as f:
+        ## Write the session token to /tmp/synacktoken ##
+        with open(self.sessionTokenPath, "w") as f:
             f.write(self.token)
         f.close()
         print("Connected to platform.")
@@ -783,17 +904,24 @@ class synack:
             driver.quit()
         if self.connector == True:
             self.webdriver = driver
-        return(0)
+        return 0
 
-###########
-## Vulns ##
-###########
+    ###########
+    ## Vulns ##
+    ###########
 
     def getVulns(self, status="accepted"):
         pageNum = 1
         results = []
         while True:
-            url_vulnerabilities = self.url_vulnerabilities +"?filters%5Bstatus%5D=" + status + "&page=" +str(pageNum)+"&per_page=5"
+            url_vulnerabilities = (
+                self.url_vulnerabilities
+                + "?filters%5Bstatus%5D="
+                + status
+                + "&page="
+                + str(pageNum)
+                + "&per_page=5"
+            )
             response = self.try_requests("GET", url_vulnerabilities, 10)
             vulnsResponse = response.json()
             if len(vulnsResponse) == 0:
@@ -803,21 +931,21 @@ class synack:
                 pageNum += 1
         return results
 
-    def getVuln(self, identifier): # e.g. optimusant-4
+    def getVuln(self, identifier):  # e.g. optimusant-4
         url_vuln = self.url_vulnerabilities + "/" + identifier
         response = self.try_requests("GET", url_vuln, 10)
         vuln_response = response.json()
         return vuln_response
 
-###########
-## Drafts ##
-###########
+    ###########
+    ## Drafts ##
+    ###########
 
     def getDrafts(self):
         pageNum = 1
         results = []
         while True:
-            url_drafts = self.url_drafts +"?page=" +str(pageNum)+"&per_page=5"
+            url_drafts = self.url_drafts + "?page=" + str(pageNum) + "&per_page=5"
             response = self.try_requests("GET", url_drafts, 10)
             draftsResponse = response.json()
             if len(draftsResponse) == 0:
@@ -836,16 +964,23 @@ class synack:
         else:
             return False
 
-###########
-## Hydra ##
-###########
+    ###########
+    ## Hydra ##
+    ###########
 
     def getHydra(self, codename):
         slug = self.getTargetID(codename)
         pageNum = 1
         hydraResults = []
         while True:
-            url_hydra = self.url_hydra +"?page=" +str(pageNum)+"&listing_uids="+slug+"&q=%2Bport_is_open%3Atrue"
+            url_hydra = (
+                self.url_hydra
+                + "?page="
+                + str(pageNum)
+                + "&listing_uids="
+                + slug
+                + "&q=%2Bport_is_open%3Atrue"
+            )
             response = self.try_requests("GET", url_hydra, 10)
             hydraResponse = response.json()
             if len(hydraResponse) == 0:
@@ -855,22 +990,22 @@ class synack:
                 pageNum += 1
         return hydraResults
 
-###################
-## Mission stuff ##
-###################
+    ###################
+    ## Mission stuff ##
+    ###################
 
-## Poll for missions ##
-## REMOVED FROM CLASS FILE ##
+    ## Poll for missions ##
+    ## REMOVED FROM CLASS FILE ##
 
-####################
-## CLAIM MISSIONS ##
-####################
+    ####################
+    ## CLAIM MISSIONS ##
+    ####################
 
-## REMOVED FROM CLASS FILE ##
+    ## REMOVED FROM CLASS FILE ##
 
-########################
-## Notification Token ##
-########################
+    ########################
+    ## Notification Token ##
+    ########################
 
     def getNotificationToken(self):
         response = self.try_requests("GET", self.url_notification_token, 10)
@@ -878,78 +1013,87 @@ class synack:
             jsonResponse = response.json()
         except:
             jsonResponse = {}
-            return(1)
-        self.notificationToken = jsonResponse['token']
-        with open(self.notificationTokenPath,"w") as f:
+            return 1
+        self.notificationToken = jsonResponse["token"]
+        with open(self.notificationTokenPath, "w") as f:
             f.write(self.notificationToken)
-        return(0)
+        return 0
 
-############################
-## Read All Notifications ##
-############################
+    ############################
+    ## Read All Notifications ##
+    ############################
 
     def markNotificationsRead(self):
         if not self.notificationToken:
             self.getNotificationToken()
-        readNotifications = self.url_notification_api+"read_all?authorization_token="+self.notificationToken
-        del self.webheaders['Authorization']
+        readNotifications = (
+            self.url_notification_api
+            + "read_all?authorization_token="
+            + self.notificationToken
+        )
+        del self.webheaders["Authorization"]
         response = self.try_requests("POST", readNotifications, 10)
-        self.webheaders['Authorization'] = "Bearer " + self.token
+        self.webheaders["Authorization"] = "Bearer " + self.token
         try:
             textResponse = str(response.content)
         except:
-            return(1)
-        return(0)
+            return 1
+        return 0
 
-########################
-## Read Notifications ##
-########################
+    ########################
+    ## Read Notifications ##
+    ########################
 
     def pollNotifications(self):
-        pageIterator=1
+        pageIterator = 1
         breakOuterLoop = 0
         notifications = []
         if not self.notificationToken:
             self.getNotificationToken()
         while True:
-            notificationsUrl = self.url_notification_api+"notifications?pagination%5Bpage%5D="+str(pageIterator)+"&pagination%5Bper_page%5D=15&meta=1"
-            self.webheaders['Authorization'] = "Bearer " + self.notificationToken
+            notificationsUrl = (
+                self.url_notification_api
+                + "notifications?pagination%5Bpage%5D="
+                + str(pageIterator)
+                + "&pagination%5Bper_page%5D=15&meta=1"
+            )
+            self.webheaders["Authorization"] = "Bearer " + self.notificationToken
             response = self.try_requests("GET", notificationsUrl, 10)
-            self.webheaders['Authorization'] = "Bearer " + self.token
+            self.webheaders["Authorization"] = "Bearer " + self.token
             try:
                 jsonResponse = response.json()
             except:
-                return(1)
+                return 1
             if not jsonResponse:
                 break
             for i in range(len(jsonResponse)):
                 if jsonResponse[i]["read"] == False:
                     notifications.append(jsonResponse[i])
                 else:
-                    breakOuterLoop=1
-                    break    
+                    breakOuterLoop = 1
+                    break
             if breakOuterLoop == 1:
                 break
             else:
-                pageIterator=pageIterator+1
-        return(notifications)
+                pageIterator = pageIterator + 1
+        return notifications
 
-#############################
-## Get Current Target Slug ##
-#############################
+    #############################
+    ## Get Current Target Slug ##
+    #############################
 
     def getCurrentTargetSlug(self):
         response = self.try_requests("GET", self.url_activate_target, 10)
         try:
             jsonResponse = response.json()
         except:
-            return(1)
-        if jsonResponse['slug']:
-            return(jsonResponse['slug'])
+            return 1
+        if jsonResponse["slug"]:
+            return jsonResponse["slug"]
 
-##############
-## Get ROEs ##
-##############
+    ##############
+    ## Get ROEs ##
+    ##############
 
     def getRoes(self, slug):
         requestURL = self.url_scope_summary + str(slug)
@@ -958,44 +1102,46 @@ class synack:
         try:
             jsonResponse = response.json()
         except:
-            return(1)
-        if not jsonResponse['roes']:
-            return(roes)
+            return 1
+        if not jsonResponse["roes"]:
+            return roes
         else:
-            for i in range(len(jsonResponse['roes'])):
-                roes.append(jsonResponse['roes'][i])
-            return(roes)
+            for i in range(len(jsonResponse["roes"])):
+                roes.append(jsonResponse["roes"][i])
+            return roes
 
-######################
-## Get Transactions ##
-######################
+    ######################
+    ## Get Transactions ##
+    ######################
     def getTransactions(self):
-        pageIterator=1
+        pageIterator = 1
         breakOuterLoop = 0
         transactions = []
         while True:
-            transactionUrl = self.url_transactions+"?page="+str(pageIterator)+"&per_page=15"
+            transactionUrl = (
+                self.url_transactions + "?page=" + str(pageIterator) + "&per_page=15"
+            )
             response = self.try_requests("GET", transactionUrl, 10)
             try:
                 jsonResponse = response.json()
             except:
-                return(1)
+                return 1
             if not jsonResponse:
                 break
             for i in range(len(jsonResponse)):
                 if jsonResponse[i]["title"] == "CashOut":
-                    if float(jsonResponse[i]['amount']) < 0:
-                        amount = float(jsonResponse[i]['amount']) * -1
+                    if float(jsonResponse[i]["amount"]) < 0:
+                        amount = float(jsonResponse[i]["amount"]) * -1
                     else:
-                        amount = float(jsonResponse[i]['amount'])
-                    ts = datetime.datetime.fromtimestamp(jsonResponse[i]['created_at'])
-                    transactions.append(ts.strftime('%Y-%m-%d')+","+str(amount))
-            pageIterator=pageIterator+1
-        return(transactions)
-        
-########################
-## Get LP Credentials ##
-########################
+                        amount = float(jsonResponse[i]["amount"])
+                    ts = datetime.datetime.fromtimestamp(jsonResponse[i]["created_at"])
+                    transactions.append(ts.strftime("%Y-%m-%d") + "," + str(amount))
+            pageIterator = pageIterator + 1
+        return transactions
+
+    ########################
+    ## Get LP Credentials ##
+    ########################
     def getLPCredentials(self):
         response = self.try_requests("GET", self.url_lp_credentials, 10)
         try:
@@ -1004,4 +1150,3 @@ class synack:
             return creds
         except:
             return
-

--- a/synack/synack.py
+++ b/synack/synack.py
@@ -32,9 +32,7 @@ class synack:
         self.assessments = []
         self.token = ""
         self.notificationToken = ""
-        self.url_registered_summary = (
-            "https://platform.synack.com/api/targets/registered_summary"
-        )
+        self.url_registered_summary = "https://platform.synack.com/api/targets/registered_summary"
         self.url_scope_summary = "https://platform.synack.com/api/targets/"
         self.url_activate_target = "https://platform.synack.com/api/launchpoint"
         self.url_assessments = "https://platform.synack.com/api/assessments"
@@ -42,19 +40,13 @@ class synack:
         self.url_drafts = "https://platform.synack.com/api/drafts"
         self.url_unregistered_slugs = "https://platform.synack.com/api/targets?filter%5Bprimary%5D=unregistered&filter%5Bsecondary%5D=all&filter%5Bcategory%5D=all&sorting%5Bfield%5D=dateUpdated&sorting%5Bdirection%5D=desc&pagination%5Bpage%5D="
         self.url_profile = "https://platform.synack.com/api/profiles/me"
-        self.url_analytics = (
-            "https://platform.synack.com/api/listing_analytics/categories?listing_id="
-        )
+        self.url_analytics = "https://platform.synack.com/api/listing_analytics/categories?listing_id="
         self.url_hydra = "https://platform.synack.com/api/hydra_search/search/"
         self.url_logout = "https://platform.synack.com/api/logout"
-        self.url_notification_token = (
-            "https://platform.synack.com/api/users/notifications_token"
-        )
+        self.url_notification_token = "https://platform.synack.com/api/users/notifications_token"
         self.url_notification_api = "https://notifications.synack.com/api/v2/"
         self.url_transactions = "https://platform.synack.com/api/transactions"
-        self.url_lp_credentials = (
-            "https://platform.synack.com/api/launchpoint/credentials"
-        )
+        self.url_lp_credentials = "https://platform.synack.com/api/launchpoint/credentials"
         self.webheaders = {}
         self.configFile = str(Path.home()) + "/.synack/synack.conf"
         self.firefoxProfile = str(Path.home()) + "/.synack/selenium.profile"
@@ -65,12 +57,8 @@ class synack:
         self.login_wait = int(self.config["DEFAULT"]["login_wait"])
         self.login_url = self.config["DEFAULT"]["login_url"]
         self.authySecret = self.config["DEFAULT"]["authy_secret"]
-        self.sessionTokenPath = self.config["DEFAULT"].get(
-            "session_token_path", "/tmp/synacktoken"
-        )
-        self.notificationTokenPath = self.config["DEFAULT"].get(
-            "notification_token_path", "/tmp/notificationtoken"
-        )
+        self.sessionTokenPath = self.config["DEFAULT"].get("session_token_path", "/tmp/synacktoken")
+        self.notificationTokenPath = self.config["DEFAULT"].get("notification_token_path", "/tmp/notificationtoken")
         self.connector = False
         self.webdriver = None
         self.headless = False
@@ -125,13 +113,7 @@ class synack:
                         putData = json.dumps({"listing_id": extra})
                         newHeaders = dict(self.webheaders)
                         newHeaders["Content-Type"] = "application/json"
-                        response = self.session.put(
-                            URL,
-                            headers=newHeaders,
-                            data=putData,
-                            proxies=proxyDict,
-                            verify=False,
-                        )
+                        response = self.session.put(URL, headers=newHeaders, data=putData, proxies=proxyDict, verify=False)
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
@@ -139,12 +121,7 @@ class synack:
                             return response
                     elif func == "GET":
                         if extra == None:
-                            response = self.session.get(
-                                URL,
-                                headers=self.webheaders,
-                                proxies=proxyDict,
-                                verify=False,
-                            )
+                            response = self.session.get(URL, headers=self.webheaders, proxies=proxyDict, verify=False)
                             if response.status_code == 401 and platform in netloc:
                                 self.connectToPlatform()
                                 self.getSessionToken()
@@ -152,26 +129,14 @@ class synack:
                                 return response
                         else:
                             parameters = {"page": extra}
-                            response = self.session.get(
-                                URL,
-                                headers=self.webheaders,
-                                params=parameters,
-                                proxies=proxyDict,
-                                verify=False,
-                            )
+                            response = self.session.get(URL, headers=self.webheaders, params=parameters, proxies=proxyDict, verify=False)
                             if response.status_code == 401 and platform in netloc:
                                 self.connectToPlatform()
                                 self.getSessionToken()
                             else:
                                 return response
                     elif func == "POST":
-                        response = self.session.post(
-                            URL,
-                            headers=self.webheaders,
-                            proxies=proxyDict,
-                            json=extra,
-                            verify=False,
-                        )
+                        response = self.session.post(URL, headers=self.webheaders, proxies=proxyDict, json=extra, verify=False)
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
@@ -181,26 +146,14 @@ class synack:
                         newHeaders = dict(self.webheaders)
                         newHeaders["Content-Type"] = "application/json"
                         # PATCH request does not support `json=` parameter
-                        response = self.session.patch(
-                            URL,
-                            headers=newHeaders,
-                            proxies=proxyDict,
-                            data=extra,
-                            verify=False,
-                        )
+                        response = self.session.patch(URL, headers=newHeaders, proxies=proxyDict, data=extra, verify=False)
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
                         else:
                             return response
                     elif func == "DELETE":
-                        response = self.session.delete(
-                            URL,
-                            headers=self.webheaders,
-                            proxies=proxyDict,
-                            json=extra,
-                            verify=False,
-                        )
+                        response = self.session.delete(URL, headers=self.webheaders, proxies=proxyDict, json=extra, verify=False)
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
@@ -216,9 +169,7 @@ class synack:
                         putData = json.dumps({"listing_id": extra})
                         newHeaders = dict(self.webheaders)
                         newHeaders["Content-Type"] = "application/json"
-                        response = self.session.put(
-                            URL, headers=newHeaders, data=putData, verify=False
-                        )
+                        response = self.session.put(URL, headers=newHeaders, data=putData, verify=False)
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
@@ -226,9 +177,7 @@ class synack:
                             return response
                     elif func == "GET":
                         if extra == None:
-                            response = self.session.get(
-                                URL, headers=self.webheaders, verify=False
-                            )
+                            response = self.session.get(URL, headers=self.webheaders, verify=False)
                             if response.status_code == 401 and platform in netloc:
                                 self.connectToPlatform()
                                 self.getSessionToken()
@@ -236,21 +185,14 @@ class synack:
                                 return response
                         else:
                             parameters = {"page": extra}
-                            response = self.session.get(
-                                URL,
-                                headers=self.webheaders,
-                                params=parameters,
-                                verify=False,
-                            )
+                            response = self.session.get(URL, headers=self.webheaders, params=parameters, verify=False)
                             if response.status_code == 401 and platform in netloc:
                                 self.connectToPlatform()
                                 self.getSessionToken()
                             else:
                                 return response
                     elif func == "POST":
-                        response = self.session.post(
-                            URL, headers=self.webheaders, json=extra, verify=False
-                        )
+                        response = self.session.post(URL, headers=self.webheaders, json=extra, verify=False)
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
@@ -260,18 +202,14 @@ class synack:
                         # PATCH request does not support `json=` parameter
                         newHeaders = dict(self.webheaders)
                         newHeaders["Content-Type"] = "application/json"
-                        response = self.session.request(
-                            "PATCH", URL, headers=newHeaders, data=extra, verify=False
-                        )
+                        response = self.session.request("PATCH", URL, headers=newHeaders, data=extra, verify=False)
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
                         else:
                             return response
                     elif func == "DELETE":
-                        response = self.session.delete(
-                            URL, headers=self.webheaders, json=extra, verify=False
-                        )
+                        response = self.session.delete(URL, headers=self.webheaders, json=extra, verify=False)
                         if response.status_code == 401 and platform in netloc:
                             self.connectToPlatform()
                             self.getSessionToken()
@@ -317,14 +255,7 @@ class synack:
     ## mission_only: True || False
     ########################################
     def getCodenames(self, category, mission_only=False):
-        categories = (
-            "web application",
-            "re",
-            "mobile",
-            "host",
-            "source code",
-            "hardware",
-        )
+        categories = ("web application", "re", "mobile", "host", "source code", "hardware")
         category = category.lower()
         if category == "web":
             category = "web application"
@@ -338,10 +269,7 @@ class synack:
         for i in range(len(self.jsonResponse)):
             if mission_only == True:
                 if self.jsonResponse[i]["vulnerability_discovery"] == False:
-                    if (
-                        self.jsonResponse[i]["category"]["name"].lower()
-                        == category.lower()
-                    ):
+                    if self.jsonResponse[i]["category"]["name"].lower() == category.lower():
                         targets.append(self.jsonResponse[i]["codename"])
                     else:
                         continue
@@ -349,10 +277,7 @@ class synack:
                     continue
             elif mission_only == False:
                 if self.jsonResponse[i]["vulnerability_discovery"] == True:
-                    if (
-                        self.jsonResponse[i]["category"]["name"].lower()
-                        == category.lower()
-                    ):
+                    if self.jsonResponse[i]["category"]["name"].lower() == category.lower():
                         targets.append(self.jsonResponse[i]["codename"])
                     else:
                         continue
@@ -497,22 +422,13 @@ class synack:
 
             return (list(inScopeRules), list(oosRules))
         if category.lower() == "host":
-            scopeURL = (
-                "https://platform.synack.com/api/targets/" + slug + "/cidrs?page=all"
-            )
+            scopeURL = "https://platform.synack.com/api/targets/" + slug + "/cidrs?page=all"
             cidrs = []
             try:
                 response = self.try_requests("GET", scopeURL, 10)
             except requests.exceptions.RequestException as e:
                 raise SystemExit(e)
-            temp = (
-                json.dumps(response.json()["cidrs"])
-                .replace("[", "")
-                .replace("]", "")
-                .replace('"', "")
-                .replace(", ", "\n")
-                .split("\n")
-            )
+            temp = json.dumps(response.json()["cidrs"]).replace("[", "").replace("]", "").replace('"', "").replace(", ", "\n").split("\n")
             cidrs.extend(temp)
             cidrs = list(set(cidrs))
             return cidrs
@@ -561,24 +477,11 @@ class synack:
         if targetType == "Web Application":
             if "value" in jsonResponse:
                 for value in range(len(jsonResponse["value"])):
-                    for exploitable_location in range(
-                        len(jsonResponse["value"][value]["exploitable_locations"])
-                    ):
+                    for exploitable_location in range(len(jsonResponse["value"][value]["exploitable_locations"])):
                         analyticsDict = {}
-                        if (
-                            jsonResponse["value"][value]["exploitable_locations"][
-                                exploitable_location
-                            ]["type"]
-                            == "url"
-                        ):
+                        if jsonResponse["value"][value]["exploitable_locations"][exploitable_location]["type"] == "url":
                             try:
-                                URI = urlparse(
-                                    str(
-                                        jsonResponse["value"][value][
-                                            "exploitable_locations"
-                                        ][exploitable_location]["value"]
-                                    )
-                                )
+                                URI = urlparse(str(jsonResponse["value"][value]["exploitable_locations"][exploitable_location]["value"]))
                                 scheme = URI.scheme
                             except:
                                 scheme = "https"
@@ -593,13 +496,9 @@ class synack:
                                 elif scheme == "https":
                                     analyticsDict["port"] = "443"
                             analyticsDict["codename"] = codename
-                            analyticsDict["vuln_category"] = str(
-                                jsonResponse["value"][value]["categories"][0]
-                            )
+                            analyticsDict["vuln_category"] = str(jsonResponse["value"][value]["categories"][0])
                             if len(jsonResponse["value"][value]["categories"]) == 2:
-                                analyticsDict["vuln_subcategory"] = str(
-                                    jsonResponse["value"][value]["categories"][1]
-                                )
+                                analyticsDict["vuln_subcategory"] = str(jsonResponse["value"][value]["categories"][1])
                             else:
                                 pass
                             analyticsDict["scheme"] = "URL"
@@ -609,12 +508,7 @@ class synack:
                                 analyticsDict["protocol"] = "http"
                                 pass
                             try:
-                                analyticsDict["vuln_location"] = (
-                                    analyticsDict["protocol"]
-                                    + "://"
-                                    + URI.netloc
-                                    + URI.path
-                                )
+                                analyticsDict["vuln_location"] = analyticsDict["protocol"] + "://" + URI.netloc + URI.path
                             except:
                                 analyticsDict["vuln_location"] = ""
                                 pass
@@ -622,9 +516,7 @@ class synack:
                                 analyticsDict["status"] = "rejected"
                             else:
                                 analyticsDict["status"] = str(
-                                    jsonResponse["value"][value][
-                                        "exploitable_locations"
-                                    ][exploitable_location]["status"]
+                                    jsonResponse["value"][value]["exploitable_locations"][exploitable_location]["status"]
                                 )
                             analytics.append(analyticsDict)
             return analytics
@@ -632,24 +524,11 @@ class synack:
             #'codename', 'vuln_category', 'vuln_subcategory', 'vuln_location', 'type', 'protocol', 'port', 'path', 'status'
             if "value" in jsonResponse:
                 for value in range(len(jsonResponse["value"])):
-                    for exploitable_location in range(
-                        len(jsonResponse["value"][value]["exploitable_locations"])
-                    ):
+                    for exploitable_location in range(len(jsonResponse["value"][value]["exploitable_locations"])):
                         analyticsDict = {}
-                        if (
-                            jsonResponse["value"][value]["exploitable_locations"][
-                                exploitable_location
-                            ]["type"]
-                            == "url"
-                        ):
+                        if jsonResponse["value"][value]["exploitable_locations"][exploitable_location]["type"] == "url":
                             try:
-                                URI = urlparse(
-                                    str(
-                                        jsonResponse["value"][value][
-                                            "exploitable_locations"
-                                        ][exploitable_location]["value"]
-                                    )
-                                )
+                                URI = urlparse(str(jsonResponse["value"][value]["exploitable_locations"][exploitable_location]["value"]))
                                 scheme = URI.scheme
                             except:
                                 scheme = "https"
@@ -664,13 +543,9 @@ class synack:
                                 elif scheme == "https":
                                     analyticsDict["port"] = "443"
                             analyticsDict["codename"] = codename
-                            analyticsDict["vuln_category"] = str(
-                                jsonResponse["value"][value]["categories"][0]
-                            )
+                            analyticsDict["vuln_category"] = str(jsonResponse["value"][value]["categories"][0])
                             if len(jsonResponse["value"][value]["categories"]) == 2:
-                                analyticsDict["vuln_subcategory"] = str(
-                                    jsonResponse["value"][value]["categories"][1]
-                                )
+                                analyticsDict["vuln_subcategory"] = str(jsonResponse["value"][value]["categories"][1])
                             else:
                                 pass
                             analyticsDict["scheme"] = "URL"
@@ -680,12 +555,7 @@ class synack:
                                 analyticsDict["protocol"] = "http"
                                 pass
                             try:
-                                analyticsDict["vuln_location"] = (
-                                    analyticsDict["protocol"]
-                                    + "://"
-                                    + URI.netloc
-                                    + URI.path
-                                )
+                                analyticsDict["vuln_location"] = analyticsDict["protocol"] + "://" + URI.netloc + URI.path
                             except:
                                 analyticsDict["vuln_location"] = ""
                                 pass
@@ -693,51 +563,32 @@ class synack:
                                 analyticsDict["status"] = "rejected"
                             else:
                                 analyticsDict["status"] = str(
-                                    jsonResponse["value"][value][
-                                        "exploitable_locations"
-                                    ][exploitable_location]["status"]
+                                    jsonResponse["value"][value]["exploitable_locations"][exploitable_location]["status"]
                                 )
                             analytics.append(analyticsDict)
-                        elif (
-                            jsonResponse["value"][value]["exploitable_locations"][
-                                exploitable_location
-                            ]["type"]
-                            == "ip"
-                        ):
+                        elif jsonResponse["value"][value]["exploitable_locations"][exploitable_location]["type"] == "ip":
                             ## IP
                             analyticsDict["codename"] = codename
-                            analyticsDict["vuln_category"] = str(
-                                jsonResponse["value"][value]["categories"][0]
-                            )
+                            analyticsDict["vuln_category"] = str(jsonResponse["value"][value]["categories"][0])
                             if len(jsonResponse["value"][value]["categories"]) == 2:
-                                analyticsDict["vuln_subcategory"] = str(
-                                    jsonResponse["value"][value]["categories"][1]
-                                )
+                                analyticsDict["vuln_subcategory"] = str(jsonResponse["value"][value]["categories"][1])
                             else:
                                 pass
                             analyticsDict["scheme"] = "HOST"
                             analyticsDict["protocol"] = str(
-                                jsonResponse["value"][value]["exploitable_locations"][
-                                    exploitable_location
-                                ]["protocol"]
+                                jsonResponse["value"][value]["exploitable_locations"][exploitable_location]["protocol"]
                             )
                             analyticsDict["vuln_location"] = str(
-                                jsonResponse["value"][value]["exploitable_locations"][
-                                    exploitable_location
-                                ]["address"]
+                                jsonResponse["value"][value]["exploitable_locations"][exploitable_location]["address"]
                             )
                             analyticsDict["port"] = str(
-                                jsonResponse["value"][value]["exploitable_locations"][
-                                    exploitable_location
-                                ]["port"]
+                                jsonResponse["value"][value]["exploitable_locations"][exploitable_location]["port"]
                             )
                             if status.lower() == "rejected":
                                 analyticsDict["status"] = "rejected"
                             else:
                                 analyticsDict["status"] = str(
-                                    jsonResponse["value"][value][
-                                        "exploitable_locations"
-                                    ][exploitable_location]["status"]
+                                    jsonResponse["value"][value]["exploitable_locations"][exploitable_location]["status"]
                                 )
                             analytics.append(analyticsDict)
             return analytics
@@ -764,11 +615,7 @@ class synack:
                 next_page = False
                 pageNum += 1
         for i in range(len(unregistered_slugs)):
-            url_register_slug = (
-                "https://platform.synack.com/api/targets/"
-                + unregistered_slugs[i]
-                + "/signup"
-            )
+            url_register_slug = "https://platform.synack.com/api/targets/" + unregistered_slugs[i] + "/signup"
             data = '{"ResearcherListing":{"terms":1}}'
             response = self.try_requests("POST", url_register_slug, 10, data)
             slug = unregistered_slugs[i]
@@ -804,18 +651,12 @@ class synack:
             if cookie_value.find("\r") > -1 or cookie_value.find("\n") > -1:
                 print("Fixing cookie %s" % cookie_name)
                 cookie_value = re.sub("\r\n *", "", cookie_value)
-                cookie_obj = requests.cookies.create_cookie(
-                    name=cookie_name, value=cookie_value, path="/"
-                )
-                self.session.cookies.clear(
-                    domain="login.synack.com", path="/", name=cookie_name
-                )
+                cookie_obj = requests.cookies.create_cookie(name=cookie_name, value=cookie_value, path="/")
+                self.session.cookies.clear(domain="login.synack.com", path="/", name=cookie_name)
                 self.session.cookies.set_cookie(cookie_obj)
 
         data = {"email": self.email, "password": self.password}
-        response = self.try_requests(
-            "POST", "https://login.synack.com/api/authenticate", 1, data
-        )
+        response = self.try_requests("POST", "https://login.synack.com/api/authenticate", 1, data)
         jsonResponse = response.json()
         if not jsonResponse["success"]:
             print("Error logging in: " + jsonResponse)
@@ -824,21 +665,15 @@ class synack:
         progress_token = jsonResponse["progress_token"]
 
         data = {"authy_token": self.getAuthy(), "progress_token": progress_token}
-        response = self.try_requests(
-            "POST", "https://login.synack.com/api/authenticate", 1, data
-        )
+        response = self.try_requests("POST", "https://login.synack.com/api/authenticate", 1, data)
         jsonResponse = response.json()
 
         grant_token = jsonResponse["grant_token"]
 
         # 2 requests required here to confirm the grant token - once to the HTML page and once to the API
-        response = self.try_requests(
-            "GET", "https://platform.synack.com/?grant_token=" + grant_token, 1
-        )
+        response = self.try_requests("GET", "https://platform.synack.com/?grant_token=" + grant_token, 1)
         self.webheaders["X-Requested-With"] = "XMLHttpRequest"
-        response = self.try_requests(
-            "GET", "https://platform.synack.com/token?grant_token=" + grant_token, 1
-        )
+        response = self.try_requests("GET", "https://platform.synack.com/token?grant_token=" + grant_token, 1)
         jsonResponse = response.json()
         access_token = jsonResponse["access_token"]
 
@@ -885,14 +720,10 @@ class synack:
         authy_path = "/html/body/div[2]/div/div/div[2]/form/fieldset/input"
         driver.find_element_by_xpath(authy_path).click()
         driver.find_element_by_xpath(authy_path).send_keys(self.getAuthy())
-        authy_submit_path = (
-            "/html/body/div[2]/div/div/div[2]/form/fieldset/div[1]/button"
-        )
+        authy_submit_path = "/html/body/div[2]/div/div/div[2]/form/fieldset/div[1]/button"
         driver.find_element_by_xpath(authy_submit_path).click()
         while True:
-            self.token = driver.execute_script(
-                "return sessionStorage.getItem('shared-session-com.synack.accessToken')"
-            )
+            self.token = driver.execute_script("return sessionStorage.getItem('shared-session-com.synack.accessToken')")
             if isinstance(self.token, str):
                 break
         ## Write the session token to /tmp/synacktoken ##
@@ -914,14 +745,7 @@ class synack:
         pageNum = 1
         results = []
         while True:
-            url_vulnerabilities = (
-                self.url_vulnerabilities
-                + "?filters%5Bstatus%5D="
-                + status
-                + "&page="
-                + str(pageNum)
-                + "&per_page=5"
-            )
+            url_vulnerabilities = self.url_vulnerabilities + "?filters%5Bstatus%5D=" + status + "&page=" + str(pageNum) + "&per_page=5"
             response = self.try_requests("GET", url_vulnerabilities, 10)
             vulnsResponse = response.json()
             if len(vulnsResponse) == 0:
@@ -973,14 +797,7 @@ class synack:
         pageNum = 1
         hydraResults = []
         while True:
-            url_hydra = (
-                self.url_hydra
-                + "?page="
-                + str(pageNum)
-                + "&listing_uids="
-                + slug
-                + "&q=%2Bport_is_open%3Atrue"
-            )
+            url_hydra = self.url_hydra + "?page=" + str(pageNum) + "&listing_uids=" + slug + "&q=%2Bport_is_open%3Atrue"
             response = self.try_requests("GET", url_hydra, 10)
             hydraResponse = response.json()
             if len(hydraResponse) == 0:
@@ -1026,11 +843,7 @@ class synack:
     def markNotificationsRead(self):
         if not self.notificationToken:
             self.getNotificationToken()
-        readNotifications = (
-            self.url_notification_api
-            + "read_all?authorization_token="
-            + self.notificationToken
-        )
+        readNotifications = self.url_notification_api + "read_all?authorization_token=" + self.notificationToken
         del self.webheaders["Authorization"]
         response = self.try_requests("POST", readNotifications, 10)
         self.webheaders["Authorization"] = "Bearer " + self.token
@@ -1118,9 +931,7 @@ class synack:
         breakOuterLoop = 0
         transactions = []
         while True:
-            transactionUrl = (
-                self.url_transactions + "?page=" + str(pageIterator) + "&per_page=15"
-            )
+            transactionUrl = self.url_transactions + "?page=" + str(pageIterator) + "&per_page=15"
             response = self.try_requests("GET", transactionUrl, 10)
             try:
                 jsonResponse = response.json()


### PR DESCRIPTION
Currently, the getScope() feature does not work because Synack changed their API.

This prompted me to try to get a fix working. In the process, I refactored some redundant code and tweaked a few things. I noticed that the current parsing was messing up on some of the scope rules, I rewrote this to address the mistakes I noticed, but it's possible that there are still some scope rules it won't parse correctly, I did not test extensively.

I updated the readme because it did not point out that you are returning two lists of dictionaries, one for "all scope" and one for "out of scope". This is very dangerous. it is definitely not obvious that this list contains out-of-scope items by default. Because of this, I also altered this so that the two dictionaries are now: list1: list of In-scope items dictionaries and list2: out-of-scope items dictionaries. I don't think the end user should have to diff the two to get a list of in-scope things.

I also ran the code through black which is where the formatting changes came from (habit). Feel free to ignore that.

Feel free to take some, all, or none of my changes as you see fit. :)